### PR TITLE
fix(helm/clusterrole): allow read on flux helm apigroups

### DIFF
--- a/helm/templates/binding.yaml
+++ b/helm/templates/binding.yaml
@@ -7,6 +7,9 @@ rules:
 - apiGroups: ["kustomize.toolkit.fluxcd.io"]
   resources: ["*" ]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["helm.toolkit.fluxcd.io"]
+  resources: ["*" ]
+  verbs: ["get", "list", "watch"]
 ---
 # Role binding definition (e.g., ingress-reader-binding.yaml)
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Description

In previous PR https://github.com/didlawowo/fluxcd-viewer/pull/4, I added compatibility with Flux HelmReleases, but forgot to update the clusterrole template.